### PR TITLE
Fea/deeplab

### DIFF
--- a/mmv_im2im/models/nets/deeplabv3_2d.py
+++ b/mmv_im2im/models/nets/deeplabv3_2d.py
@@ -1,5 +1,5 @@
-# ADAPTED FROM https://pytorch.org/vision/main/_modules/torchvision/models/segmentation/deeplabv3.html
-# and https://discuss.pytorch.org/t/how-to-modify-deeplabv3-and-fcn-models-for-grayscale-images/52688
+# ADAPTED FROM https://pytorch.org/vision/main/_modules/torchvision/models/segmentation/deeplabv3.html  # noqa E501
+# and https://discuss.pytorch.org/t/how-to-modify-deeplabv3-and-fcn-models-for-grayscale-images/52688  # noqa E501
 
 import torch
 from mmv_im2im.utils.misc import parse_config

--- a/mmv_im2im/models/pl_FCN.py
+++ b/mmv_im2im/models/pl_FCN.py
@@ -62,7 +62,7 @@ class Model(pl.LightningModule):
         y = batch["GT"]
         if "CM" in batch.keys():
             assert (
-                self.masked_loss == True
+                self.masked_loss
             ), "Costmap is detected in training data, but not set up in criterion"
             cm = batch["CM"]
 


### PR DESCRIPTION
add deeplabv3 2d and fix masked loss for FCN --> now, we can use deeplabv3 for 2d semantic segmentation with costmap