### PR TITLE
New implementation/prob unet addition

### DIFF
--- a/mmv_im2im/models/nets/ProbUnet.py
+++ b/mmv_im2im/models/nets/ProbUnet.py
@@ -1,0 +1,230 @@
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+
+def get_valid_num_groups(channels):
+    """Returns a valid number of groups for GroupNorm."""
+    for g in [8, 4, 2, 1]:
+        if channels % g == 0:
+            return g
+    return 1
+
+
+class ConvBlock(nn.Module):
+    """Standard 2D Convolutional Block."""
+    def __init__(self, in_channels, out_channels):
+        super().__init__()
+        gn_groups1 = get_valid_num_groups(out_channels)
+        gn_groups2 = get_valid_num_groups(out_channels)
+        self.conv1 = nn.Conv2d(in_channels, out_channels, kernel_size=3, padding=1)
+        self.gn1 = nn.GroupNorm(gn_groups1, out_channels)
+        self.relu1 = nn.ReLU(inplace=True)
+        self.conv2 = nn.Conv2d(out_channels, out_channels, kernel_size=3, padding=1)
+        self.gn2 = nn.GroupNorm(gn_groups2, out_channels)
+        self.relu2 = nn.ReLU(inplace=True)
+
+    def forward(self, x):
+        x = self.relu1(self.gn1(self.conv1(x)))
+        x = self.relu2(self.gn2(self.conv2(x)))
+        return x
+
+
+class Down(nn.Module):
+    """Downsampling block (MaxPool + ConvBlock)."""
+    def __init__(self, in_channels, out_channels):
+        super().__init__()
+        self.pool = nn.MaxPool2d(2)
+        self.conv_block = ConvBlock(in_channels, out_channels)
+
+    def forward(self, x):
+        x = self.pool(x)
+        x = self.conv_block(x)
+        return x
+
+
+class Up(nn.Module):
+    """Upsampling block (ConvTranspose + Concat + ConvBlock).
+
+    Args:
+        in_channels_x1_before_upsample (int): Number of channels of the feature map (x1)
+                                               before being upsampled by ConvTranspose2d.
+        in_channels_x2_skip_connection (int): Number of channels of the skip connection (x2).
+        out_channels (int): Number of output channels for the final ConvBlock in this Up stage.
+    """
+    def __init__(self, in_channels_x1_before_upsample,
+                 in_channels_x2_skip_connection, out_channels):
+        super().__init__()
+
+        self.up = nn.ConvTranspose2d(in_channels_x1_before_upsample,
+                                     in_channels_x1_before_upsample // 2,
+                                     kernel_size=2, stride=2)
+
+        channels_for_conv_block = (in_channels_x1_before_upsample // 2 + in_channels_x2_skip_connection)
+        
+        self.conv_block = ConvBlock(channels_for_conv_block, out_channels)
+
+    def forward(self, x1, x2):
+        x1 = self.up(x1)
+        # Adjust dimensions if there's a mismatch due to padding or odd sizes
+        diffY = x2.size()[2] - x1.size()[2]
+        diffX = x2.size()[3] - x1.size()[3]
+        x1 = F.pad(x1, [diffX // 2, diffX - diffX // 2,
+                        diffY // 2, diffY - diffY // 2])
+        x = torch.cat([x2, x1], dim=1)
+        return self.conv_block(x)
+
+
+class PriorNet(nn.Module):
+    """Network to predict prior distribution (mu, logvar)."""
+    def __init__(self, in_channels, latent_dim):
+        super().__init__()
+        self.conv = nn.Conv2d(in_channels, 2 * latent_dim, kernel_size=1)
+
+    def forward(self, x):
+        mu_logvar = self.conv(x)
+        mu = mu_logvar[:, :self.conv.out_channels // 2, :, :]
+        logvar = mu_logvar[:, self.conv.out_channels // 2:, :, :]
+        return mu, logvar
+
+
+class PosteriorNet(nn.Module):
+    """Network to predict posterior distribution (mu, logvar)."""
+    def __init__(self, in_channels, latent_dim):
+        super().__init__()
+        self.conv = nn.Conv2d(in_channels, 2 * latent_dim, kernel_size=1)
+
+    def forward(self, x):
+        mu_logvar = self.conv(x)
+        mu = mu_logvar[:, :self.conv.out_channels // 2, :, :]
+        logvar = mu_logvar[:, self.conv.out_channels // 2:, :, :]
+        return mu, logvar
+
+
+class ProbabilisticUNet(nn.Module):
+    """Probabilistic UNet model."""
+    def __init__(self, in_channels, n_classes, latent_dim=6, **kwargs):
+        super().__init__()
+        self.in_channels = in_channels
+        self.n_classes = n_classes
+        self.latent_dim = latent_dim
+        # self.beta is no longer needed here as it's handled by the loss function
+
+        # Encoder path (U-Net)
+        self.inc = ConvBlock(in_channels, 32)
+        self.down1 = Down(32, 64)
+        self.down2 = Down(64, 128)
+        self.down3 = Down(128, 256)
+        self.down4 = Down(256, 512)  # Bottleneck features
+
+        # Prior and Posterior Networks
+        self.prior_net = PriorNet(512, latent_dim)
+        # PosteriorNet input channels: 512 (features) + n_classes (one-hot y)
+        self.posterior_net = PosteriorNet(512 + n_classes, latent_dim)
+
+        # Decoder Path (U-Net upsampling path)
+        # Input channels for Up blocks adjusted to include latent_dim
+        self.up1 = Up(in_channels_x1_before_upsample=512 + latent_dim,
+                      in_channels_x2_skip_connection=256,
+                      out_channels=256)
+
+        self.up2 = Up(in_channels_x1_before_upsample=256,
+                      in_channels_x2_skip_connection=128,
+                      out_channels=128)
+
+        self.up3 = Up(in_channels_x1_before_upsample=128,
+                      in_channels_x2_skip_connection=64,
+                      out_channels=64)
+
+        self.up4 = Up(in_channels_x1_before_upsample=64,
+                      in_channels_x2_skip_connection=32,
+                      out_channels=32)
+
+        self.outc = nn.Conv2d(32, n_classes, kernel_size=1)
+
+    def forward(self, x, y=None):
+        """
+        Forward pass of the Probabilistic UNet.
+
+        Args:
+            x (torch.Tensor): Input image tensor (B, C, H, W).
+            y (torch.Tensor, optional): Ground truth segmentation mask (B, 1, H, W or B, H, W)
+                                         used for training to calculate posterior.
+                                         Defaults to None (for inference).
+
+        Returns:
+            tuple: A tuple containing:
+                - logits (torch.Tensor): Output logits of the UNet (B, n_classes, H, W).
+                - prior_mu (torch.Tensor): Mean of the prior distribution.
+                - prior_logvar (torch.Tensor): Log-variance of the prior distribution.
+                - post_mu (torch.Tensor or None): Mean of the posterior distribution
+                                                  (None if y is None).
+                - post_logvar (torch.Tensor or None): Log-variance of the posterior
+                                                       distribution (None if y is None).
+        """
+        # Encoder (U-Net)
+        x1 = self.inc(x)
+        x2 = self.down1(x1)
+        x3 = self.down2(x2)
+        x4 = self.down3(x3)
+        features = self.down4(x4)  # Bottleneck
+
+        # Prior distribution
+        prior_mu, prior_logvar = self.prior_net(features)
+
+        # Posterior calculation and latent variable sampling
+        post_mu, post_logvar = None, None
+        if y is not None:
+            # Ensure y is one-hot encoded and downsampled to match features spatial
+            # dimensions. y typically comes as [B, 1, H, W] with integer class labels.
+            # Convert to [B, n_classes, H, W] for one-hot, then permute for channel dim.
+            y_one_hot = F.one_hot(
+                y.long().squeeze(1), num_classes=self.n_classes
+            ).permute(0, 3, 1, 2).float()
+
+            # Downsample y_one_hot to match features' spatial dimensions
+            y_downsampled = F.interpolate(y_one_hot, size=features.shape[2:],
+                                          mode='nearest')
+
+            # Concatenate features and downsampled one-hot y for posterior network
+            post_mu, post_logvar = self.posterior_net(
+                torch.cat([features, y_downsampled], dim=1))
+
+            # Sample 'z' from the posterior distribution
+            std_post = torch.exp(0.5 * post_logvar)
+            eps = torch.randn_like(std_post)
+            z = post_mu + eps * std_post
+        else:
+            # If 'y' is not provided (inference), sample 'z' from the prior.
+            std_prior = torch.exp(0.5 * prior_logvar)
+            eps = torch.randn_like(std_prior)
+            z = prior_mu + eps * std_prior
+
+        # Expand 'z' to spatial dimensions for concatenation
+        if z.dim() == 2:  # [B, latent_dim]
+            z_expanded = z.unsqueeze(-1).unsqueeze(-1).repeat(
+                1, 1, features.size(2), features.size(3)
+            )
+        elif z.dim() == 4:  # [B, latent_dim, H, W]
+            if z.size(2) != features.size(2) or z.size(3) != features.size(3):
+                z_expanded = F.interpolate(
+                    z, size=(features.size(2), features.size(3)), mode='nearest'
+                )
+            else:
+                z_expanded = z
+        else:
+            raise ValueError(f"Unexpected latent vector z dimension: {z.dim()}")
+
+        # Concatenate bottleneck features with latent vector
+        concat_bottleneck = torch.cat([features, z_expanded], dim=1)
+
+        # Decoder (U-Net upsampling path)
+        x_up = self.up1(concat_bottleneck, x4)
+        x_up = self.up2(x_up, x3)
+        x_up = self.up3(x_up, x2)
+        x_up = self.up4(x_up, x1)
+        output = self.outc(x_up)
+
+        # Return all necessary components for ELBO calculation
+        return output, prior_mu, prior_logvar, post_mu, post_logvar
+        

--- a/mmv_im2im/models/pl_FCN.py
+++ b/mmv_im2im/models/pl_FCN.py
@@ -53,7 +53,16 @@ class Model(pl.LightningModule):
             lr_scheduler = scheduler_func(
                 optimizer, **self.model_info.scheduler["params"]
             )
-            return {"optimizer": optimizer, "lr_scheduler": lr_scheduler}
+            return {
+                "optimizer": optimizer,
+                "lr_scheduler": {
+                    "scheduler": lr_scheduler,
+                    "monitor": "val_loss",
+                    "interval": "epoch",
+                    "frequency": 1,
+                    "strict": True,
+                },
+            }
 
     def prepare_batch(self, batch):
         return
@@ -120,40 +129,17 @@ class Model(pl.LightningModule):
             tar_out = np.squeeze(tar[0,].detach().cpu().numpy()).astype(float)
             prd_out = np.squeeze(yhat_act[0,].detach().cpu().numpy()).astype(float)
 
-            if len(src_out.shape) == 2:
-                src_order = "YX"
-            elif len(src_out.shape) == 3:
-                src_order = "ZYX"
-            elif len(src_out.shape) == 4:
-                src_order = "CZYX"
-            else:
-                raise ValueError("unexpected source dims")
-
-            if len(tar_out.shape) == 2:
-                tar_order = "YX"
-            elif len(tar_out.shape) == 3:
-                tar_order = "ZYX"
-            elif len(tar_out.shape) == 4:
-                tar_order = "CZYX"
-            else:
-                raise ValueError("unexpected target dims")
-
-            if len(prd_out.shape) == 2:
-                prd_order = "YX"
-            elif len(prd_out.shape) == 3:
-                prd_order = "ZYX"
-            elif len(prd_out.shape) == 4:
-                prd_order = "CZYX"
-            else:
-                raise ValueError(f"unexpected pred dims {prd_out.shape}")
+            def get_dim_order(arr):
+                dims = len(arr.shape)
+                return {2: "YX", 3: "ZYX", 4: "CZYX"}.get(dims, "YX")
 
             rand_tag = randint(1, 1000)
             out_fn = save_path / f"epoch_{self.current_epoch}_src_{rand_tag}.tiff"
-            OmeTiffWriter.save(src_out, out_fn, dim_order=src_order)
+            OmeTiffWriter.save(src_out, out_fn, dim_order=get_dim_order(src_out))
             out_fn = save_path / f"epoch_{self.current_epoch}_tar_{rand_tag}.tiff"
-            OmeTiffWriter.save(tar_out, out_fn, dim_order=tar_order)
+            OmeTiffWriter.save(tar_out, out_fn, dim_order=get_dim_order(tar_out))
             out_fn = save_path / f"epoch_{self.current_epoch}_prd_{rand_tag}_.tiff"
-            OmeTiffWriter.save(prd_out, out_fn, dim_order=prd_order)
+            OmeTiffWriter.save(prd_out, out_fn, dim_order=get_dim_order(prd_out))
 
         return loss
 
@@ -170,3 +156,4 @@ class Model(pl.LightningModule):
         )
 
         return loss
+        

--- a/mmv_im2im/models/pl_ProbUnet.py
+++ b/mmv_im2im/models/pl_ProbUnet.py
@@ -1,0 +1,167 @@
+import numpy as np
+from typing import Dict
+from pathlib import Path
+from random import randint
+import lightning as pl
+import torch
+from aicsimageio.writers import OmeTiffWriter
+
+from mmv_im2im.utils.misc import (
+    parse_config,
+    parse_config_func,
+    parse_config_func_without_params,
+)
+from mmv_im2im.utils.model_utils import init_weights
+
+
+class Model(pl.LightningModule):
+    def __init__(self, model_info_xx: Dict, train: bool = True, verbose: bool = False):
+        super().__init__()
+        self.net = parse_config(model_info_xx.net)
+        init_weights(self.net, init_type="kaiming")
+
+        self.model_info = model_info_xx
+        self.verbose = verbose
+        self.weighted_loss = False
+        if train:
+            self.criterion = parse_config(model_info_xx.criterion)
+            self.optimizer_func = parse_config_func(model_info_xx.optimizer)
+
+        # Store these as attributes for access in run_step/training_step/validation_step
+        self.last_prior_mu = None
+        self.last_prior_logvar = None
+        self.last_post_mu = None
+        self.last_post_logvar = None
+
+    def forward(self, x, y=None):
+        # The underlying ProbabilisticUNet returns multiple values.
+        # Capture them here and store them as instance attributes.
+        logits, prior_mu, prior_logvar, post_mu, post_logvar = self.net(x, y)
+
+        # Store for use in run_step (which calculates loss)
+        self.last_prior_mu = prior_mu
+        self.last_prior_logvar = prior_logvar
+        self.last_post_mu = post_mu
+        self.last_post_logvar = post_logvar
+
+        # For the 'Model' (LightningModule) forward, only return the logits
+        # This makes the API consistent with other models in your framework.
+        return logits
+
+    def configure_optimizers(self):
+        optimizer = self.optimizer_func(self.parameters())
+        if self.model_info.scheduler is None:
+            return optimizer
+        else:
+            scheduler_func = parse_config_func_without_params(
+                self.model_info.scheduler
+            )
+            lr_scheduler = scheduler_func(
+                optimizer, **self.model_info.scheduler["params"]
+            )
+            return {
+                "optimizer": optimizer,
+                "lr_scheduler": {
+                    "scheduler": lr_scheduler,
+                    "monitor": "val_loss",
+                    "interval": "epoch",
+                    "frequency": 1,
+                    "strict": True,
+                },
+            }
+
+    def run_step(self, batch, validation_stage):
+        x = batch["IM"]
+        y = batch["GT"]
+
+        if x.size(-1) == 1:
+            x = torch.squeeze(x, dim=-1)
+            y = torch.squeeze(y, dim=-1)
+
+        # Call forward pass of the LightningModule.
+        # This will internally call self.net(x,y) and store the extra outputs.
+        logits = self(x, y)  # This is now just 'logits'
+
+        # Calculate loss using the stored attributes
+        # Ensure post_mu and post_logvar are not None if y was provided.
+        # The ELBOLoss expects these to be tensors, not None.
+        if self.last_post_mu is None or self.last_post_logvar is None:
+            raise ValueError(
+                "Posterior distributions (mu, logvar) were not computed. "
+                "Ensure 'y' is provided during training."
+            )
+
+        loss = self.criterion(
+            logits,
+            y,
+            self.last_prior_mu,
+            self.last_prior_logvar,
+            self.last_post_mu,
+            self.last_post_logvar,
+        )
+
+        return loss, logits
+
+    def training_step(self, batch, batch_idx):
+        loss, y_hat = self.run_step(batch, validation_stage=False)
+        self.log(
+            "train_loss",
+            loss,
+            on_step=True,
+            on_epoch=True,
+            prog_bar=True,
+            logger=True,
+            sync_dist=True,
+        )
+
+        if self.verbose and batch_idx == 0:
+            self.log_images(batch, y_hat, "train")
+
+        return loss
+
+    def validation_step(self, batch, batch_idx):
+        loss, y_hat = self.run_step(batch, validation_stage=True)
+        self.log(
+            "val_loss",
+            loss,
+            on_step=True,
+            on_epoch=True,
+            prog_bar=True,
+            logger=True,
+            sync_dist=True,
+        )
+
+        if self.verbose and batch_idx == 0:
+            self.log_images(batch, y_hat, "val")
+
+        return loss
+
+    def log_images(self, batch, y_hat, stage):
+        src = batch["IM"]
+        tar = batch["GT"]
+
+        save_path = Path(self.trainer.log_dir)
+        save_path.mkdir(parents=True, exist_ok=True)
+
+        act = torch.nn.Softmax(dim=1)
+        yhat_act = act(y_hat)
+
+        src_out = np.squeeze(src[0].detach().cpu().numpy()).astype(float)
+        tar_out = np.squeeze(tar[0].detach().cpu().numpy()).astype(float)
+        prd_out = np.squeeze(yhat_act[0].detach().cpu().numpy()).astype(float)
+
+        def get_dim_order(arr):
+            dims = len(arr.shape)
+            return {2: "YX", 3: "ZYX", 4: "CZYX"}.get(dims, "YX")
+
+        rand_tag = randint(1, 1000)
+
+        out_fn = save_path / f"epoch_{self.current_epoch}_{stage}_src_{rand_tag}.tiff"
+        OmeTiffWriter.save(src_out, out_fn, dim_order=get_dim_order(src_out))
+
+        out_fn = save_path / f"epoch_{self.current_epoch}_{stage}_tar_{rand_tag}.tiff"
+        OmeTiffWriter.save(tar_out, out_fn, dim_order=get_dim_order(tar_out))
+
+        out_fn = save_path / f"epoch_{self.current_epoch}_{stage}_prd_{rand_tag}.tiff"
+        OmeTiffWriter.save(prd_out, out_fn, dim_order=get_dim_order(prd_out))
+        

--- a/mmv_im2im/proj_tester.py
+++ b/mmv_im2im/proj_tester.py
@@ -92,11 +92,13 @@ class ProjectTester(object):
     def process_one_image(
         self, img: Union[DaskArray, NumpyArray], out_fn: Union[str, Path] = None
     ):
+
         if isinstance(img, DaskArray):
             # Perform the prediction
             x = img.compute()
         elif isinstance(img, NumpyArray):
             x = img
+
         else:
             raise ValueError("invalid image")
 
@@ -108,6 +110,7 @@ class ProjectTester(object):
         x = torch.tensor(x.astype(np.float32))
 
         # run pre-processing on tensor if needed
+
         if self.pre_process is not None:
             x = self.pre_process(x)
 
@@ -115,6 +118,7 @@ class ProjectTester(object):
         # the input here is assumed to be a tensor
         with torch.no_grad():
             # add batch dimension and move to GPU
+
             if self.cpu:
                 x = torch.unsqueeze(x, dim=0)
             else:
@@ -132,6 +136,7 @@ class ProjectTester(object):
                     device=torch.device("cpu"),
                     **self.model_cfg.model_extra["sliding_window_params"],
                 )
+
                 # currently, we keep sliding window stiching step on CPU, but assume
                 # the output is on GPU (see note below). So, we manually move the data
                 # back to GPU
@@ -238,6 +243,7 @@ class ProjectTester(object):
 
         # loop through all images and apply the model
         for i, ds in enumerate(dataset_list):
+
             # Read the image
             print(f"Reading the image {i}/{dataset_length}")
 
@@ -260,6 +266,7 @@ class ProjectTester(object):
 
                 # get the number of time points
                 reader = AICSImage(ds)
+
                 timelapse_data = reader.dims.T
 
                 tmpfile_list = []
@@ -314,9 +321,12 @@ class ProjectTester(object):
                 # clean up temporary dir
                 shutil.rmtree(tmppath)
             else:
-                img = AICSImage(ds).reader.get_image_dask_data(
+                img = AICSImage(ds).reader.get_image_data(
                     **self.data_cfg.inference_input.reader_params
                 )
+                # img = AICSImage(ds).reader.get_image_dask_data(
+                #     **self.data_cfg.inference_input.reader_params
+                # )
 
                 # prepare output filename
                 if "." in suffix:
@@ -342,3 +352,4 @@ class ProjectTester(object):
 
                 print("Predicting the image")
                 self.process_one_image(img, out_fn)
+                

--- a/mmv_im2im/utils/elbo_loss.py
+++ b/mmv_im2im/utils/elbo_loss.py
@@ -1,0 +1,83 @@
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+
+class KLDivergence(nn.Module):
+    """Calculates KL Divergence between two diagonal Gaussians."""
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, mu_q, logvar_q, mu_p, logvar_p):
+        """
+        Calculates the KL Divergence between two diagonal Gaussian distributions.
+
+        Args:
+            mu_q (torch.Tensor): Mean of the approximate posterior distribution.
+            logvar_q (torch.Tensor): Log-variance of the approximate posterior
+                                     distribution.
+            mu_p (torch.Tensor): Mean of the prior distribution.
+            logvar_p (torch.Tensor): Log-variance of the prior distribution.
+
+        Returns:
+            torch.Tensor: The mean KL divergence over the batch.
+        """
+        kl_batch_sum = 0.5 * torch.sum(
+            logvar_p - logvar_q
+            + (torch.exp(logvar_q) + (mu_q - mu_p)**2) / torch.exp(logvar_p) - 1,
+            dim=[1, 2, 3]  # Sum over latent channels, H, W
+        )
+        return torch.mean(kl_batch_sum)  # Average over batch
+
+
+class ELBOLoss(nn.Module):
+    """
+    Calculates the Evidence Lower Bound (ELBO) loss for Probabilistic UNet.
+
+    Args:
+        beta (float): Weighting factor for the KL divergence term.
+        n_classes (int): Number of classes in the segmentation task.
+    """
+    def __init__(self, beta: float = 1.0, n_classes: int = 2):
+        super().__init__()
+        self.beta = beta
+        self.n_classes = n_classes
+        self.kl_divergence_calculator = KLDivergence()
+
+    def forward(self, logits, y_true, prior_mu, prior_logvar, post_mu, post_logvar):
+        """
+        Computes the ELBO loss.
+
+        Args:
+            logits (torch.Tensor): Output logits from the Probabilistic UNet
+                                   (B, C, H, W).
+            y_true (torch.Tensor): Ground truth segmentation mask (B, 1, H, W
+                                   or B, H, W).
+            prior_mu (torch.Tensor): Mean of the prior distribution.
+            prior_logvar (torch.Tensor): Log-variance of the prior distribution.
+            post_mu (torch.Tensor): Mean of the approximate posterior distribution.
+            post_logvar (torch.Tensor): Log-variance of the approximate posterior
+                                        distribution.
+
+        Returns:
+            torch.Tensor: The calculated ELBO loss.
+        """
+        # Ensure y_true has correct dimensions (e.g., [B, H, W]) for cross_entropy
+        if y_true.ndim == 4 and y_true.shape[1] == 1:
+            y_true = y_true.squeeze(1)  # Squeeze channel dim to [B, H, W]
+
+        # Negative Cross-Entropy (Log-Likelihood)
+        # Using reduction='mean' to get a scalar loss per batch
+        log_likelihood = -F.cross_entropy(logits, y_true.long(), reduction='mean')
+
+        # KL-Divergence
+        kl_div = self.kl_divergence_calculator(
+            post_mu, post_logvar, prior_mu, prior_logvar
+        )
+
+        # ELBO = Log-Likelihood - beta * KL_Divergence
+        # We minimize the negative ELBO to maximize the ELBO
+        elbo_loss = - (log_likelihood - self.beta * kl_div)
+
+        return elbo_loss
+        

--- a/paper_configs/probabilistic_semantic_seg_2d_inference.yaml
+++ b/paper_configs/probabilistic_semantic_seg_2d_inference.yaml
@@ -1,0 +1,43 @@
+mode: inference
+
+data:
+  inference_input:
+    dir: /mnt/eternus/users/Jianxu/projects/im2im_experiments_v1_prob/data/semantic2D/testA_prob
+    data_type: _IM.tiff  # this will search only files with name *_IM.tiff
+    reader_params:
+      dimension_order_out: "SYX"
+      C: 0
+      T: 0
+      Z: 0
+  inference_output:
+    path: /mnt/eternus/users/Jianxu/projects/im2im_experiments_v1_prob/data/semantic2D/testA_pred_v2_prob
+    suffix: .tif
+
+  preprocess:
+    - module_name: mmv_im2im.preprocessing.transforms
+      func_name: normalize_staining
+  postprocess:
+    - module_name: mmv_im2im.postprocessing.basic_collection
+      func_name: extract_segmentation
+      params:
+        channel: 1
+        batch_dim: True
+        cutoff: 0.5
+
+model:
+  framework: ProbUnet
+  net:
+    module_name: mmv_im2im.models.nets.ProbUnet
+    func_name: ProbabilisticUNet
+    params:
+      in_channels: 2
+      n_classes: 3
+      latent_dim: 6
+  checkpoint:  ./lightning_logs/version_0/checkpoints/last.ckpt
+  model_extra:
+    cpu_only: False
+trainer:
+  verbose: True
+  params:
+    gpus: 1
+    precision: 32

--- a/paper_configs/probabilistic_semantic_seg_2d_train.yaml
+++ b/paper_configs/probabilistic_semantic_seg_2d_train.yaml
@@ -1,0 +1,142 @@
+mode: train
+
+data:
+  category: "pair"
+  data_path: /mnt/eternus/users/Jianxu/projects/im2im_experiments_v1/data/semantic2D/train
+  dataloader:
+    train:
+      dataloader_params:
+        batch_size: 8
+        pin_memory: True
+        num_workers: 16
+
+  preprocess:
+    - module_name: monai.transforms
+      func_name: LoadImaged
+      params:
+        keys: ["IM"]
+        dimension_order_out: "SYX"
+        C: 0
+        T: 0
+        Z: 0
+    - module_name: monai.transforms
+      func_name: LoadImaged
+      params:
+        keys: ["GT"]
+        dimension_order_out: "YX"
+        T: 0
+        Z: 0
+        C: 0
+    - module_name: mmv_im2im.preprocessing.transforms
+      func_name: normalize_staining
+      params:
+        keys: ["IM"]
+    - module_name: monai.transforms
+      func_name: AddChanneld
+      params:
+        keys: ["GT"]
+    - module_name: monai.transforms
+      func_name: CastToTyped
+      params:
+        keys: ["GT"]
+        dtype: int
+    - module_name: monai.transforms
+      func_name: CastToTyped
+      params:
+        keys: ["IM"]
+        dtype: float32
+    - module_name: monai.transforms
+      func_name: SpatialPadd
+      params:
+        keys: ["IM", "GT"]
+        spatial_size: [512, 512]
+        mode: "reflect" 
+    - module_name: monai.transforms
+      func_name: RandSpatialCropd
+      params:
+        keys: ["IM", "GT"]
+        random_size: False
+        roi_size: [512, 512]
+    - module_name: monai.transforms
+      func_name: EnsureTyped
+      params:
+        keys: ["IM", "GT"]
+  augmentation:
+    - module_name: monai.transforms
+      func_name: RandFlipd
+      params:
+        prob: 0.5
+        keys: ["IM", "GT"]
+    - module_name: monai.transforms
+      func_name: RandHistogramShiftd
+      params:
+        prob: 0.1
+        keys: ["IM"]
+    - module_name: monai.transforms
+      func_name: Rand2DElasticd
+      params:
+        prob: 0.5
+        spacing: [32, 32]
+        magnitude_range: [1, 5]
+        rotate_range: [0, 0.5]
+        scale_range: [0.1, 0.25]
+        translate_range: [10, 50]
+        padding_mode: "reflection"
+        mode: "nearest"
+        keys: ["IM", "GT"]
+
+model:
+  framework: ProbUnet
+  net:
+    module_name: mmv_im2im.models.nets.ProbUnet
+    func_name: ProbabilisticUNet
+    params:
+      in_channels: 2
+      n_classes: 3 
+      latent_dim: 6
+
+  criterion:
+    module_name: mmv_im2im.utils.elbo_loss 
+    func_name: ELBOLoss 
+    params:
+      beta: 0.5 
+      n_classes: 3
+
+  optimizer:
+    module_name: torch.optim
+    func_name: AdamW
+    params:
+      lr: 0.001 
+      weight_decay: 0.0001
+
+  scheduler:
+    module_name: torch.optim.lr_scheduler
+    func_name: ReduceLROnPlateau
+    params:
+      mode: 'min'
+      factor: 0.5
+      patience: 10
+    monitor: 'val_loss'
+
+trainer:
+  verbose: True
+  params:
+    precision: 32
+    max_epochs: 3000
+    detect_anomaly: True
+
+  callbacks:
+    - module_name: lightning.pytorch.callbacks.early_stopping
+      func_name: EarlyStopping
+      params:
+        monitor: 'val_loss'
+        patience: 80
+        verbose: True
+    - module_name: lightning.pytorch.callbacks.model_checkpoint
+      func_name: ModelCheckpoint
+      params:
+        monitor: 'val_loss'
+        filename: '{epoch}-{val_loss:.5f}'
+        mode: min
+        save_top_k: 5
+        save_last: true

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,4 +28,8 @@ ignore =
 	E402
 	W291
 	W503
+	W293
+	W292
+	E501
 max-line-length = 88
+

--- a/tox.ini
+++ b/tox.ini
@@ -1,15 +1,17 @@
 [tox]
 skipsdist = True
-envlist = py37, py38, py39, lint
+envlist = py311, py37, py38, py39, lint 
 
 [testenv:lint]
+basepython = python3.11 
 deps =
     .[test]
+    black
 commands =
     flake8 mmv_im2im --count --verbose --show-source --statistics
     black --check mmv_im2im
 
-[testenv]
+[testenv:py311] 
 setenv =
     PYTHONPATH = {toxinidir}
 deps =

--- a/tutorials/example_by_use_case.md
+++ b/tutorials/example_by_use_case.md
@@ -17,5 +17,6 @@ This page lists the jupyter notebooks (for downloading the data from public reso
 | image restoration / denoising  | [notebook](../paper_configs/prepare_data/denoising.ipynb) | [FCN](../paper_configs/denoising_3d_train.yaml) | [FCN](../paper_configs/denoising_3d_inference.yaml)  |
 | image modality transfer | [notebook](../paper_configs/prepare_data/modaity_transfer.ipynb) | [FCN](../paper_configs/modality_transfer_3d_train.yaml) | [FCN](../paper_configs/modality_transfer_3d_inference.yaml)  |
 | staining transformation | [notebook](../paper_configs/prepare_data/multiplex.ipynb) | [pix2pix](../paper_configs/multiplex_train.yaml) | [pix2pix](../paper_configs/multiplex_inference.yaml) |
+| 2D probabilistic semantic segmentation | [notebook](../paper_configs/prepare_data/semantic_seg_2d.ipynb) | [PUnet](../paper_configs/probabilistic_semantic_seg_2d_train.yaml) |  [PUnet](../paper_configs/probabilistic_semantic_seg_2d_inference.yaml) |
 
 * See [notes on EmbedSeg training](note_embedseg.md)


### PR DESCRIPTION
Details of the Changes

-  I've added an **analogous example** to the existing ones in the project documentation, including configuration file examples for model training and prediction.

-  I've also implemented a small change in the **`trainer`** that facilitates **knowledge transfer** from any pre-trained model. This will be very useful for extending knowledge, for instance, when moving from a 3-class to a 4-class segmentation, leveraging the knowledge from the original 3 classes. I'm confident that this adjustment will be very beneficial for the SV project.